### PR TITLE
Normalize boolean values for chart counts

### DIFF
--- a/site.html
+++ b/site.html
@@ -149,8 +149,10 @@ function updateCharts() {
 
   tableData.forEach(row => {
     inboundCounts[row[3]] = (inboundCounts[row[3]] || 0) + 1;
-    upgradeCounts[row[1]] = (upgradeCounts[row[1]] || 0) + 1;
-    hardwareCounts[row[4]] = (hardwareCounts[row[4]] || 0) + 1;
+    const upgradeKey = String(row[1]).toLowerCase() === 'true' ? 'TRUE' : 'FALSE';
+    const hardwareKey = String(row[4]).toLowerCase() === 'true' ? 'TRUE' : 'FALSE';
+    upgradeCounts[upgradeKey] = (upgradeCounts[upgradeKey] || 0) + 1;
+    hardwareCounts[hardwareKey] = (hardwareCounts[hardwareKey] || 0) + 1;
   });
 
   new Chart(document.getElementById('inboundChart'), {


### PR DESCRIPTION
## Summary
- Ensure upgrade and hardware charts count boolean values case-insensitively

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689db07a29d88324b15266dea16757fa